### PR TITLE
Convert available_worker set to a queue

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,8 @@
             warn_export_vars,
             warn_exported_vars,
             warn_missing_spec,
-            warn_untyped_record, debug_info]}.
+            warn_untyped_record, debug_info,
+            {platform_define, "^[0-9]+", namespaced_queues}]}.
 {deps_dir, "deps"}.
 {deps, [
  {lager,  "2.1.1", {git, "git@github.com:tigertext/lager.git", {tag, "2.1.1"} }},

--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -16,7 +16,7 @@
 -module(wpool).
 -author('elbrujohalcon@inaka.net').
 
--define(DEFAULTS, [{overrun_warning, infinity}, {overrun_handler, {error_logger, warning_report}}, {workers, 100}, {worker, {wpool_worker, [{hibernate, always}]}}]).
+-define(DEFAULTS, [{overrun_warning, infinity}, {overrun_handler, {error_logger, warning_report}}, {workers, 100}]).
 
 -type name() :: atom().
 -type option() :: {overrun_warning, infinity|pos_integer()} | {overrun_handler, {Module::atom(), Fun::atom()}} | {workers, pos_integer()} | {worker, {Module::atom(), InitArg::term()}}.

--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -16,7 +16,7 @@
 -module(wpool).
 -author('elbrujohalcon@inaka.net').
 
--define(DEFAULTS, [{overrun_warning, infinity}, {overrun_handler, {error_logger, warning_report}}, {workers, 100}]).
+-define(DEFAULTS, [{overrun_warning, infinity}, {overrun_handler, {error_logger, warning_report}}, {workers, 100}, {worker, {wpool_worker, undefined}}]).
 
 -type name() :: atom().
 -type option() :: {overrun_warning, infinity|pos_integer()} | {overrun_handler, {Module::atom(), Fun::atom()}} | {workers, pos_integer()} | {worker, {Module::atom(), InitArg::term()}}.

--- a/src/wpool.erl
+++ b/src/wpool.erl
@@ -16,7 +16,7 @@
 -module(wpool).
 -author('elbrujohalcon@inaka.net').
 
--define(DEFAULTS, [{overrun_warning, infinity}, {overrun_handler, {error_logger, warning_report}}, {workers, 100}, {worker, {wpool_worker, undefined}}]).
+-define(DEFAULTS, [{overrun_warning, infinity}, {overrun_handler, {error_logger, warning_report}}, {workers, 100}, {worker, {wpool_worker, [{hibernate, always}]}}]).
 
 -type name() :: atom().
 -type option() :: {overrun_warning, infinity|pos_integer()} | {overrun_handler, {Module::atom(), Fun::atom()}} | {workers, pos_integer()} | {worker, {Module::atom(), InitArg::term()}}.

--- a/src/wpool_pool.erl
+++ b/src/wpool_pool.erl
@@ -143,6 +143,7 @@ worker_names(Pool_Name) ->
 init({Name, Options}) ->
     {Worker, InitArgs}  = proplists:get_value(worker, Options, {wpool_worker, [{hibernate, always}]}),
     Workers             = proplists:get_value(workers, Options, 100),
+    Worker_Collection   = proplists:get_value(worker_collection_type, Options, gb_sets),
     Strategy            = proplists:get_value(strategy, Options, {one_for_one, 5, 60}),
     OverrunHandler      = proplists:get_value(overrun_handler, Options, {error_logger, warning_report}),
     TimeChecker         = time_checker_name(Name),
@@ -150,7 +151,7 @@ init({Name, Options}) ->
     _Wpool = store_wpool(#wpool{name = Name, size = Workers, next = 1, opts = Options, qmanager = QueueManager}),
     {ok, {Strategy,
           [{TimeChecker, {wpool_time_checker, start_link, [Name, TimeChecker, OverrunHandler]}, permanent, brutal_kill, worker, [wpool_time_checker]},
-           {QueueManager, {wpool_queue_manager, start_link, [Name, QueueManager]}, permanent, brutal_kill, worker, [wpool_queue_manager]} |
+           {QueueManager, {wpool_queue_manager, start_link, [Name, QueueManager, Worker_Collection]}, permanent, brutal_kill, worker, [wpool_queue_manager]} |
             [{worker_name(Name, I),
                 {wpool_process, start_link,
                  [worker_name(Name, I), Worker, InitArgs,

--- a/src/wpool_queue_manager.erl
+++ b/src/wpool_queue_manager.erl
@@ -28,11 +28,21 @@
 
 -include("wpool.hrl").
 
+-ifdef(namespaced_queues).
+-type client_queue() :: queue:queue().
+-type worker_queue() :: queue:queue().
+-type worker_set()   :: gb_sets:set(atom()).
+-else.
+-type client_queue() :: queue().
+-type worker_queue() :: queue().
+-type worker_set()   :: gb_sets:set(atom()).
+-endif.
+
 -type worker_collection_type() :: gb_sets | queue.
 
 -record(state, {wpool                  :: wpool:name(),
-                clients                :: queue(),
-                workers                :: gb_sets:set(atom()) | queue(),
+                clients                :: client_queue(),
+                workers                :: worker_set() | worker_queue(),
                 born = os:timestamp()  :: erlang:timestamp(),
                 worker_collection_type :: worker_collection_type()
                }).

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -95,7 +95,7 @@ stats(_Config) ->
 	10 = Get(workers, Options),
 	10 = Get(size, InitStats),
 	1 = Get(next_worker, InitStats),
-	{wpool_worker, [{hibernate, always}]} = Get(worker, Options),
+	undefined = Get(worker, Options),
 	InitWorkers = Get(workers, InitStats),
 	10 = length(InitWorkers),
 	[begin

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -11,7 +11,6 @@
 % KIND, either express or implied.  See the License for the
 % specific language governing permissions and limitations
 % under the License.
-
 -module(wpool_SUITE).
 
 -type config() :: [{atom(), term()}].
@@ -19,7 +18,7 @@
 -export([all/0]).
 -export([init_per_suite/1, end_per_suite/1]).
 -export([stats/1, stop_pool/1, overrun/1]).
--export([bench/1, overrun_handler/1]).
+-export([overrun_handler/1]).
 
 -spec all() -> [atom()].
 all() -> [Fun || {Fun, 1} <- module_info(exports), Fun =/= init_per_suite, Fun =/= end_per_suite, Fun =/= module_info, Fun =/= overrun_handler].
@@ -94,14 +93,14 @@ stats(_Config) ->
 	10 = Get(workers, Options),
 	10 = Get(size, InitStats),
 	1 = Get(next_worker, InitStats),
-	undefined = Get(worker, Options),
+	{wpool_worker, undefined} = Get(worker, Options),
 	InitWorkers = Get(workers, InitStats),
 	10 = length(InitWorkers),
 	[begin
 		WorkerStats = Get(I, InitWorkers),
 		0 = Get(message_queue_len, WorkerStats),
-                [] = [Stat || {Key, _Val} = Stat <- WorkerStats,
-                              not lists:member(Key, [message_queue_len, memory, reductions])]
+	        [] = [Stat || {Key, _Val} = Stat <- WorkerStats,
+	                      not lists:member(Key, [message_queue_len, memory, reductions])]
 	 end || I <- lists:seq(1, 10)],
 
 	% Start a long task on every worker

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -12,7 +12,6 @@
 % specific language governing permissions and limitations
 % under the License.
 
-%% @hidden
 -module(wpool_SUITE).
 
 -type config() :: [{atom(), term()}].

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -18,7 +18,7 @@
 -export([all/0]).
 -export([init_per_suite/1, end_per_suite/1]).
 -export([stats/1, stop_pool/1, overrun/1]).
--export([overrun_handler/1]).
+-export([bench/1, overrun_handler/1]).
 
 -spec all() -> [atom()].
 all() -> [Fun || {Fun, 1} <- module_info(exports), Fun =/= init_per_suite, Fun =/= end_per_suite, Fun =/= module_info, Fun =/= overrun_handler].
@@ -93,7 +93,7 @@ stats(_Config) ->
 	10 = Get(workers, Options),
 	10 = Get(size, InitStats),
 	1 = Get(next_worker, InitStats),
-	{wpool_worker, undefined} = Get(worker, Options),
+	{wpool_worker, [{hibernate, always}]} = Get(worker, Options),
 	InitWorkers = Get(workers, InitStats),
 	10 = length(InitWorkers),
 	[begin

--- a/test/wpool_SUITE.erl
+++ b/test/wpool_SUITE.erl
@@ -74,13 +74,21 @@ stop_pool(_Config) ->
 
 -spec stats(config()) -> _.
 stats(_Config) ->
+	ok = test_pool(10, default),
+	ok = test_pool(10, [{worker_collection_type, gb_sets}]),
+	ok = test_pool(10, [{worker_collection_type, queue}]).
+
+test_pool(Worker_Count, Worker_Options) ->
 	Get = fun proplists:get_value/2,
 
 	try wpool:stats(?MODULE)
 	catch _:no_workers -> ok
 	end,
 
-	{ok, PoolPid} = wpool:start_pool(?MODULE, [{workers, 10}]),
+	{ok, PoolPid} = case Worker_Options of
+                            default -> wpool:start_sup_pool(?MODULE, [{workers, Worker_Count}]);
+                            _ -> wpool:start_sup_pool(?MODULE, [{workers, Worker_Count} | Worker_Options])
+                        end,
 	true = is_pid(PoolPid),
 
 	% Checks ...

--- a/test/wpool_bench.erl
+++ b/test/wpool_bench.erl
@@ -31,7 +31,6 @@ run_tasks(TaskGroups, Strategy, Options) ->
         wpool:stop_pool(?MODULE)
     end.
 
-
 %% @doc Returns the transactions per second for simulated redis calls
 -spec run_redis(wpool:strategy(), [wpool:option()], string()) -> pos_integer().
 run_redis(Strategy, Options, Label) ->

--- a/test/wpool_bench.erl
+++ b/test/wpool_bench.erl
@@ -33,6 +33,7 @@ run_tasks(TaskGroups, Strategy, Options) ->
 
 %% @doc Returns the transactions per second for simulated redis calls
 -spec run_redis(wpool:strategy(), [wpool:option()], string()) -> pos_integer().
+
 run_redis(Strategy, Options, Label) ->
     {ok, _Pool} = wpool:start_sup_pool(redis, Options),
     Num_Transactions = 10000,

--- a/test/wpool_pool_SUITE.erl
+++ b/test/wpool_pool_SUITE.erl
@@ -96,7 +96,7 @@ available_worker(_Config) ->
 	0 = proplists:get_value(total_message_queue_len, Stats2),
 
 	ct:log("Now they all should be free"),
-        ct:log("We get half of them working for a while"),
+	ct:log("We get half of them working for a while"),
 	[wpool:cast(Pool, {timer, sleep, [60000]}) || _ <- lists:seq(1, ?WORKERS, 2)],
 	timer:sleep(500),
 

--- a/test/wpool_process_SUITE.erl
+++ b/test/wpool_process_SUITE.erl
@@ -71,7 +71,7 @@ cast(_Config) ->
 	wpool_process:cast(Pid, {noreply, newstate}),
 	newstate = wpool_process:call(?MODULE, state, 5000),
 	wpool_process:cast(Pid, {noreply, newerstate, 1}),
-	timer:sleep(1),
+	timer:sleep(50),
 	timeout = wpool_process:call(?MODULE, state, 5000),
 	wpool_process:cast(Pid, {stop, normal, state}),
 	timer:sleep(1000),


### PR DESCRIPTION
The drawback of this approach is that every time a worker dies (generally whenever pressure on our system is highest), the entire queue has to be scanned and rewritten to remove any occurrences of the dead worker. This cost is greater than visiting a list of elements because filter runs across head and tail separately and doesn't coalesce, so it has to do a  reverse on the tail of the queue in addition to the scan.
